### PR TITLE
SYS-16874: Add RNapp switcher for the UAT in the Mock Sydney SSO tool

### DIFF
--- a/pages/saml/sydney.tsx
+++ b/pages/saml/sydney.tsx
@@ -292,7 +292,7 @@ export default function Sydney() {
     setShowMockEligibilityForm(false);
   }, [allowMockEligibilitySection]);
 
-  const allowUseReactNativeToggle = !['prod', 'uat'].includes(ssoFormState.targetEnvironment);
+  const allowUseReactNativeToggle = !['prod'].includes(ssoFormState.targetEnvironment);
   useEffect(() => {
     setUseReactNative(false);
   }, [allowUseReactNativeToggle]);

--- a/utils/settings.ts
+++ b/utils/settings.ts
@@ -41,7 +41,8 @@ const samlConfigMap: Record<WfhEnv, SamlConfig> = {
     agApiKey: process.env.AG_API_KEY ?? 'e020b2a6-30af-46f6-9524-c33dc0598461',
   },
   uat: {
-    acs: 'https://anthem-staging.buildinghealthyfamilies.ai' + acsPath,
+    acs: 'https://anthem-rnapp.uat.wildflowerhealth.digital/' + acsPath,
+    acsCordovaWebAppDomain: 'https://anthem-staging.buildinghealthyfamilies.ai/' + acsPath,
     audience: 'com.wildflowerhealth.saml.uat',
   },
   prod: {


### PR DESCRIPTION
- Enable React Native toggle for UAT environment
- Add acsCordovaWebAppDomain configuration for UAT
- Update toggle visibility to exclude only prod environment