### PR TITLE
SYS-17369: Fix eligibilityFormData not syncing on SSO form change

### DIFF
--- a/components/MockEligibility.tsx
+++ b/components/MockEligibility.tsx
@@ -76,12 +76,15 @@ export default function MockEligibility(props: MockEligibilityProps) {
   });
 
   useEffect(() => {
-    setFormData({
+    const { fundingType, ...SSOFormDataWithoutFundingType } = SSOFormData;
+    const updatedFormData = {
       ...formData,
-      ...SSOFormData,
+      ...SSOFormDataWithoutFundingType,
       fundingTypeCd: SSOFormData.fundingType,
       underwritingStateCd: SSOFormData.stateCode,
-    });
+    };
+    setFormData(updatedFormData);
+    onDataChange?.(updatedFormData);
   }, [SSOFormData]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- When "Use Mock Eligibility" is enabled on the Sydney SSO page, changing a field on the left-side form (e.g., firstName) was not updating the `eligibilityFormData` in the JSON display on the right
- Root cause: the `useEffect` in `MockEligibility` that syncs `SSOFormData` prop changes into local state was not calling `onDataChange` to notify the parent
- Also fixed: removed accidental spread of `fundingType` into eligibility data (it should only appear as `fundingTypeCd`)

## Test plan
- [ ] Run mock-saml dev server (`npm run dev`)
- [ ] Go to `/saml/sydney`, enable "Use Mock Eligibility"
- [ ] Change a field on the left (e.g., firstName) and verify `eligibilityFormData` in the JSON updates immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)