### PR TITLE
SYS-17625: Add mock Cigna Auth0 endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,87 +1,79 @@
-# Mock SAML from BoxyHQ
+# Mock SSO
 
-[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
-[![Deploy with Vercel](https://vercel.com/button)](<https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fboxyhq%2Fmock-saml&env=APP_URL,ENTITY_ID,PUBLIC_KEY,PRIVATE_KEY,NEXT_PUBLIC_GTM_ID&envDescription=APP_URL%20(Usually%20https%3A%2F%2F%3Cproject-name%3E.vercel.app)%20can%20be%20set%20after%20deployment%20from%20the%20project%20dashboard.%20Set%20to%20''%20if%20not%20applicable.&envLink=https%3A%2F%2Fgithub.com%2Fboxyhq%2Fmock-saml%2Fblob%2Fmain%2F.env.example&project-name=mock-saml>)
+Mock identity provider service for testing SSO integrations. Supports SAML 2.0 (Sydney/Anthem) and OAuth2/OIDC (Cigna Auth0).
 
-Mock SAML is a free SAML 2.0 Identity Provider for testing SAML SSO integrations.
+Forked from [BoxyHQ/mock-saml](https://github.com/boxyhq/mock-saml).
 
-## Namespaces
+## Mock Providers
 
-Try [Mock SAML](https://mocksaml.com/), our free hosted service. Whilst we use the root domain for our own testing you can create your own unique namespace by navigating to [https://mocksaml.com/namespace/any_name_of_your_choice](https://mocksaml.com/namespace/any_name_of_your_choice).
+| Provider    | Type        | Page                     | Description                                                                   |
+| ----------- | ----------- | ------------------------ | ----------------------------------------------------------------------------- |
+| Sydney SSO  | SAML 2.0    | `/saml/sydney`           | Anthem/Sydney SAML IdP with configurable user attributes and mock eligibility |
+| Cigna Auth0 | OAuth2/OIDC | `/cigna-auth0/authorize` | Mock Cigna Auth0 with test users, token exchange, and mock API endpoints      |
 
-## Install
-
-### With Docker
-
-The docker container can be found at [boxyhq/mock-saml](https://hub.docker.com/r/boxyhq/mock-saml).
+## Quick Start
 
 ```bash
-docker run \
-  -p 4000:4000 \
-  -e APP_URL="http://localhost:4000" \
-  -e ENTITY_ID="https://saml.example.com/entityid" \
-  -e PUBLIC_KEY="<PUBLIC_KEY>" \
-  -e PRIVATE_KEY="<PRIVATE_KEY>" \
-  -d boxyhq/mock-saml
-```
-
-Refer to [env.example](https://github.com/boxyhq/mock-saml/blob/main/.env.example#L5C3-L5C97) for instructions on how to create the key pair.
-Replace `<PUBLIC_KEY>` with Base64 encoded value of public key.
-Replace `<PRIVATE_KEY>` with Base64 encoded value of private key.
-
-### Without Docker
-
-```
-git clone https://github.com/boxyhq/mock-saml.git
-```
-
-```
-cd mock-saml
-```
-
-Install dependencies
-
-```
 npm install
+npm run serve    # Build and start on port 4123
 ```
 
-Update `.env` with your own keys.
+Open http://localhost:4123 to see both providers.
 
-```
-cp .env.example .env
-```
+## Scripts
 
-Build the Next.js app.
+| Command                | Description                                                       |
+| ---------------------- | ----------------------------------------------------------------- |
+| `npm run serve`        | Build and start the production server (recommended for local use) |
+| `npm run dev`          | Start dev server with hot reload (clears `.next` cache first)     |
+| `npm run build`        | Build for production                                              |
+| `npm start`            | Start production server (requires `npm run build` first)          |
+| `npm run lint`         | Run ESLint                                                        |
+| `npm run format`       | Format with Prettier                                              |
+| `npm run check-format` | Check formatting                                                  |
 
-```
-npm run build
-```
+## Cigna Auth0 Mock
 
-Run the Mock SAML server.
+### Endpoints
 
-```
-npm run start
-```
+| Path                                                    | Method | Description                                        |
+| ------------------------------------------------------- | ------ | -------------------------------------------------- |
+| `/cigna-auth0/authorize`                                | GET    | Login page with test user selection                |
+| `/api/cigna-auth0/authorize/callback`                   | POST   | Validates credentials, generates auth code         |
+| `/api/cigna-auth0/oauth/token`                          | POST   | Token exchange (authorization_code, refresh_token) |
+| `/api/cigna-auth0/rtde/v1/userinfo`                     | GET    | User profile (requires Bearer token)               |
+| `/api/cigna-auth0/rtde/v1/biometrics`                   | GET    | Biometric data (requires Bearer token)             |
+| `/api/cigna-auth0/rtde/v1/surveyresponses`              | POST   | Create survey response (requires Bearer token)     |
+| `/api/cigna-auth0/rtde/v1/surveyresponses/:id/complete` | GET    | Complete survey (requires Bearer token)            |
+| `/api/cigna-auth0/rtde/v3/incentives`                   | GET    | Incentives/rewards (requires Bearer token)         |
+| `/api/cigna-auth0/well-known/openid-configuration`      | GET    | OIDC discovery document                            |
 
-## Contributing
+### URL Rewrites (local dev)
 
-Thanks for taking the time to contribute! Contributions make the open-source community a fantastic place to learn, inspire, and create. Any contributions you make are greatly appreciated.
+These Next.js rewrites allow the app-gateway to call standard OAuth/API paths directly on `localhost:4123` without a path prefix:
 
-Please try to create bug reports that are:
+- `/oauth/token` → `/api/cigna-auth0/oauth/token`
+- `/rtde/*` → `/api/cigna-auth0/rtde/*`
+- `/.well-known/openid-configuration` → `/api/cigna-auth0/well-known/openid-configuration`
 
-- _Reproducible._ Include steps to reproduce the problem.
-- _Specific._ Include as much detail as possible: which version, what environment, etc.
-- _Unique._ Do not duplicate existing opened issues.
-- _Scoped to a Single Bug._ One bug per report.
+### Test Users
 
-## Community
+| Username     | Password     | Employer | Products                   |
+| ------------ | ------------ | -------- | -------------------------- |
+| JoePlayer    | nflmycigna1  | Cigna    | None                       |
+| testfujifilm | Fujifilm1    | Fujifilm | Healthy Pregnancies/Babies |
+| Holt25       | Titans35     | MNPS     | Healthy Pregnancies/Babies |
+| Testcitizens | Citizens2015 | Citizens | Healthy Pregnancies/Babies |
 
-- [Discord](https://discord.gg/uyb7pYt4Pa) (For live discussion with the Open-Source Community and BoxyHQ team)
-- [Twitter](https://twitter.com/BoxyHQ) (Follow us)
-- [GitHub Issues](https://https://github.com/boxyhq/mock-saml/issues) (Contributions, report issues and product ideas)
+### Logging
 
-# Mock SAML Sydney
+All Cigna Auth0 endpoints log to the console with `[mock-cigna-auth0]` prefix, including request data, user info, and response bodies for survey/userinfo endpoints.
 
-```
-baseUrl/saml/sydney
-```
+## Deployed
+
+- **Mock SAML (Sydney)**: `sso-saml.wfh-test.net`
+- **Mock Cigna Auth0**: `mock-cigna-auth0.dev.wildflowerhealth.net` (via nginx routing to this service)
+
+## Environment Variables
+
+See `.env.example` for SAML-specific configuration (keys, entity ID, etc.). The Cigna Auth0 mock requires no additional configuration.

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,44 +1,8 @@
 export default function Footer() {
   return (
     <footer className='body-font text-gray-600'>
-      <div className='container mx-auto flex flex-col items-center px-5 py-8 sm:flex-row'>
-        <a className='title-font flex items-center justify-center font-medium text-gray-900 md:justify-start'>
-          <svg
-            xmlns='http://www.w3.org/2000/svg'
-            fill='none'
-            stroke='currentColor'
-            strokeLinecap='round'
-            strokeLinejoin='round'
-            strokeWidth={2}
-            className='h-10 w-10 rounded-full bg-indigo-500 p-2 text-white'
-            viewBox='0 0 24 24'>
-            <path d='M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5' />
-          </svg>
-          <span className='ml-3 text-xl'>Mock SAML</span>
-        </a>
-        <p className='mt-4 text-sm text-gray-500 sm:ml-4 sm:mt-0 sm:border-l-2 sm:border-gray-200 sm:py-2 sm:pl-4'>
-          Powered by
-          <a
-            href='https://boxyhq.com/'
-            className='ml-1 text-gray-600'
-            rel='noopener noreferrer'
-            target='_blank'>
-            <strong>BoxyHQ</strong>
-          </a>
-        </p>
-        <span className='mt-4 inline-flex justify-center sm:ml-auto sm:mt-0 sm:justify-start'>
-          <a className='ml-3 text-gray-500'>
-            <svg
-              fill='currentColor'
-              strokeLinecap='round'
-              strokeLinejoin='round'
-              strokeWidth={2}
-              className='h-5 w-5'
-              viewBox='0 0 24 24'>
-              <path d='M23 3a10.9 10.9 0 01-3.14 1.53 4.48 4.48 0 00-7.86 3v1A10.66 10.66 0 013 4s-4 9 5 13a11.64 11.64 0 01-7 2c9 5 20 0 20-11.5a4.5 4.5 0 00-.08-.83A7.72 7.72 0 0023 3z' />
-            </svg>
-          </a>
-        </span>
+      <div className='container mx-auto flex items-center px-5 py-8'>
+        <p className='text-sm text-gray-500'>Mock SSO — internal dev/QA tool</p>
       </div>
     </footer>
   );

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -3,41 +3,10 @@ import Link from 'next/link';
 export default function Header() {
   return (
     <header className='body-font border-b px-2 text-gray-600'>
-      <div className='container mx-auto flex flex-col flex-wrap items-center justify-between space-y-2 py-3 md:flex-row'>
-        <Link
-          href='https://github.com/boxyhq/mock-saml'
-          target='_blank'
-          className='title-font flex items-center font-medium text-gray-900 md:mb-0'>
-          <svg
-            xmlns='http://www.w3.org/2000/svg'
-            fill='none'
-            stroke='currentColor'
-            strokeLinecap='round'
-            strokeLinejoin='round'
-            strokeWidth={2}
-            className='h-10 w-10 rounded-full bg-indigo-500 p-2 text-white'
-            viewBox='0 0 24 24'>
-            <path d='M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5' />
-          </svg>
-          <span className='ml-3 text-2xl'>Mock SAML</span>
+      <div className='container mx-auto flex items-center py-3'>
+        <Link href='/' className='title-font font-medium text-gray-900'>
+          <span className='text-2xl'>Mock SSO</span>
         </Link>
-        <div className='flex flex-col items-center space-y-2 md:flex-row md:space-y-0 md:space-x-2'>
-          <span>
-            <a
-              className='btn-outline btn-sm btn'
-              href='https://github.com/boxyhq/jackson'
-              rel='noopener noreferrer'
-              target='_blank'>
-              Integrate SAML with a few lines of code
-            </a>
-          </span>
-          <span>
-            Made with <span className='text-red-500'>&#9829;</span>{' '}
-            <a href='https://boxyhq.com/' rel='noopener noreferrer' target='_blank'>
-              <strong>BoxyHQ</strong>
-            </a>
-          </span>
-        </div>
       </div>
     </header>
   );

--- a/lib/cigna-auth0/middleware.ts
+++ b/lib/cigna-auth0/middleware.ts
@@ -1,0 +1,33 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { accessTokens } from './store';
+
+interface BearerResult {
+  userId: string;
+}
+
+/**
+ * Validates the Bearer token from the Authorization header.
+ * Returns the userId if valid, or sends a 401 response and returns null.
+ */
+export function requireBearer(req: NextApiRequest, res: NextApiResponse): BearerResult | null {
+  const auth = req.headers.authorization;
+  if (!auth || !auth.startsWith('Bearer ')) {
+    res.status(401).json({
+      errors: [{ message: 'Missing or invalid Authorization header' }],
+    });
+    return null;
+  }
+
+  const token = auth.slice(7);
+  const stored = accessTokens.get(token);
+
+  if (!stored || stored.expiresAt < Date.now()) {
+    accessTokens.delete(token);
+    res.status(401).json({
+      errors: [{ message: 'Token expired or invalid' }],
+    });
+    return null;
+  }
+
+  return { userId: stored.userId };
+}

--- a/lib/cigna-auth0/store.ts
+++ b/lib/cigna-auth0/store.ts
@@ -1,0 +1,32 @@
+import crypto from 'crypto';
+
+export interface AuthCodeEntry {
+  userId: string;
+  redirectUri: string;
+  state: string;
+  expiresAt: number;
+}
+
+export interface AccessTokenEntry {
+  userId: string;
+  expiresAt: number;
+}
+
+export interface RefreshTokenEntry {
+  userId: string;
+}
+
+// In-memory stores. These persist across requests in Next.js standalone mode
+// (single long-running Node process). In dev mode (next dev), module hot-reload
+// may clear these — that's acceptable for a mock service.
+export const authCodes = new Map<string, AuthCodeEntry>();
+export const accessTokens = new Map<string, AccessTokenEntry>();
+export const refreshTokens = new Map<string, RefreshTokenEntry>();
+
+export function generateToken(prefix: string): string {
+  return `mock-${prefix}-${crypto.randomBytes(16).toString('hex')}`;
+}
+
+export function generateAuthCode(): string {
+  return crypto.randomBytes(20).toString('hex');
+}

--- a/lib/cigna-auth0/test-users.ts
+++ b/lib/cigna-auth0/test-users.ts
@@ -1,0 +1,63 @@
+export interface CignaTestUser {
+  password: string;
+  sub: string;
+  given_name: string;
+  family_name: string;
+  email: string;
+  birthdate: string;
+  gender: string;
+  employer_id: string;
+  employer_name: string;
+  products: string[];
+}
+
+export const TEST_USERS: Record<string, CignaTestUser> = {
+  JoePlayer: {
+    password: 'nflmycigna1',
+    sub: 'MOCK-MEMBER-001',
+    given_name: 'Joe',
+    family_name: 'Player',
+    email: 'joeplayer@test.cigna.com',
+    birthdate: '1990-01-15T00:00:00Z',
+    gender: 'female',
+    employer_id: '3174704',
+    employer_name: 'Cigna',
+    products: [],
+  },
+  testfujifilm: {
+    password: 'Fujifilm1',
+    sub: 'MOCK-MEMBER-002',
+    given_name: 'Test',
+    family_name: 'Fujifilm',
+    email: 'testfujifilm@test.cigna.com',
+    birthdate: '1988-06-20T00:00:00Z',
+    gender: 'female',
+    employer_id: '3209976',
+    employer_name: 'Fujifilm',
+    products: ['/cigna/eligibility/feature/benefit/cignahealthypregnanciesandbabies'],
+  },
+  Holt25: {
+    password: 'Titans35',
+    sub: 'MOCK-MEMBER-003',
+    given_name: 'Holt',
+    family_name: 'Twenty-Five',
+    email: 'holt25@test.cigna.com',
+    birthdate: '1992-03-10T00:00:00Z',
+    gender: 'female',
+    employer_id: '3333770',
+    employer_name: 'MNPS',
+    products: ['/cigna/eligibility/feature/benefit/cignahealthypregnanciesandbabies'],
+  },
+  Testcitizens: {
+    password: 'Citizens2015',
+    sub: 'MOCK-MEMBER-004',
+    given_name: 'Test',
+    family_name: 'Citizens',
+    email: 'testcitizens@test.cigna.com',
+    birthdate: '1985-11-05T00:00:00Z',
+    gender: 'female',
+    employer_id: '3331040',
+    employer_name: 'Citizens',
+    products: ['/cigna/eligibility/feature/benefit/cignahealthypregnanciesandbabies'],
+  },
+};

--- a/next.config.js
+++ b/next.config.js
@@ -3,6 +3,19 @@ module.exports = {
   experimental: { esmExternals: false, webpackBuildWorker: true },
   reactStrictMode: true,
   output: 'standalone',
+  async rewrites() {
+    return [
+      // Local dev: app-gateway calls http://localhost:4000/oauth/token
+      { source: '/oauth/:path*', destination: '/api/cigna-auth0/oauth/:path*' },
+      // Local dev: app-gateway calls http://localhost:4000/rtde/v1/userinfo etc.
+      { source: '/rtde/:path*', destination: '/api/cigna-auth0/rtde/:path*' },
+      // .well-known can't be a Next.js directory name
+      {
+        source: '/.well-known/openid-configuration',
+        destination: '/api/cigna-auth0/well-known/openid-configuration',
+      },
+    ];
+  },
   webpack: (config, { isServer }) => {
     if (!isServer) {
       config.resolve.fallback = {

--- a/package.json
+++ b/package.json
@@ -1,20 +1,20 @@
 {
   "name": "@wildflowerhealth/mock-saml",
   "version": "1.3.9",
-  "description": "Mock SAML is a free SAML 2.0 Identity Provider for testing SAML SSO integrations.",
+  "description": "Mock SSO service for testing SAML and OAuth2/OIDC integrations.",
   "private": true,
   "license": "Apache 2.0",
   "wfh": {
     "fork": true
   },
   "scripts": {
-    "dev": "next dev -p 4123",
+    "dev": "rm -rf .next && next dev -p 4123",
     "build": "next build",
     "start": "next start -p 4123",
+    "serve": "next build && next start -p 4123",
     "lint": "next lint",
     "check-format": "prettier --check .",
-    "format": "prettier --write .",
-    "release": "git checkout release && git merge origin/main && release-it && git checkout main && git merge origin/release && git push origin main"
+    "format": "prettier --write ."
   },
   "dependencies": {
     "@boxyhq/saml20": "1.5.1",

--- a/pages/api/cigna-auth0/authorize/callback.ts
+++ b/pages/api/cigna-auth0/authorize/callback.ts
@@ -1,0 +1,37 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { TEST_USERS } from '../../../../lib/cigna-auth0/test-users';
+import { authCodes, generateAuthCode } from '../../../../lib/cigna-auth0/store';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const { username, password, redirect_uri, state } = req.body;
+  const user = TEST_USERS[username];
+
+  console.log('[mock-cigna-auth0] POST /authorize/callback', {
+    username,
+    redirect_uri,
+    state,
+  });
+
+  if (!user || user.password !== password) {
+    console.log('[mock-cigna-auth0] Auth failed for user:', username);
+    return res.status(401).json({ error: 'Invalid credentials' });
+  }
+
+  const code = generateAuthCode();
+  authCodes.set(code, {
+    userId: username,
+    redirectUri: redirect_uri,
+    state,
+    expiresAt: Date.now() + 5 * 60 * 1000,
+  });
+
+  const separator = redirect_uri.includes('?') ? '&' : '?';
+  const redirectUrl = `${redirect_uri}${separator}code=${code}&state=${state}`;
+
+  console.log('[mock-cigna-auth0] Auth success, code issued for:', username);
+  return res.status(200).json({ redirectUrl });
+}

--- a/pages/api/cigna-auth0/oauth/token.ts
+++ b/pages/api/cigna-auth0/oauth/token.ts
@@ -1,0 +1,83 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { authCodes, accessTokens, refreshTokens, generateToken } from '../../../../lib/cigna-auth0/store';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  // app-gateway's buildUrl() puts all params in the query string
+  const grant_type = (req.query.grant_type || req.body?.grant_type) as string;
+  const code = (req.query.code || req.body?.code) as string;
+  const refresh_token = (req.query.refresh_token || req.body?.refresh_token) as string;
+
+  console.log('[mock-cigna-auth0] POST /oauth/token', {
+    grant_type,
+    code: code ? `${code.slice(0, 8)}...` : undefined,
+    refresh_token: refresh_token ? `${refresh_token.slice(0, 12)}...` : undefined,
+    query_keys: Object.keys(req.query),
+    body_keys: req.body ? Object.keys(req.body) : [],
+  });
+
+  if (grant_type === 'authorization_code') {
+    const authCode = authCodes.get(code);
+    if (!authCode || authCode.expiresAt < Date.now()) {
+      authCodes.delete(code);
+      console.log('[mock-cigna-auth0] Token exchange failed: invalid/expired code');
+      return res.status(400).json({
+        error: 'invalid_grant',
+        error_description: 'Invalid or expired authorization code',
+      });
+    }
+    authCodes.delete(code);
+
+    const at = generateToken('at');
+    const rt = generateToken('rt');
+    accessTokens.set(at, {
+      userId: authCode.userId,
+      expiresAt: Date.now() + 3600 * 1000,
+    });
+    refreshTokens.set(rt, { userId: authCode.userId });
+
+    console.log('[mock-cigna-auth0] Token exchange success for user:', authCode.userId);
+    return res.json({
+      access_token: at,
+      refresh_token: rt,
+      id_token: generateToken('id'),
+      expires_in: 3600,
+      token_type: 'Bearer',
+    });
+  }
+
+  if (grant_type === 'refresh_token') {
+    const stored = refreshTokens.get(refresh_token);
+    if (!stored) {
+      console.log('[mock-cigna-auth0] Refresh failed: invalid token');
+      return res.status(400).json({
+        error: 'invalid_grant',
+        error_description: 'Invalid refresh token',
+      });
+    }
+
+    const at = generateToken('at');
+    const newRt = generateToken('rt');
+    accessTokens.set(at, {
+      userId: stored.userId,
+      expiresAt: Date.now() + 3600 * 1000,
+    });
+    refreshTokens.delete(refresh_token);
+    refreshTokens.set(newRt, { userId: stored.userId });
+
+    console.log('[mock-cigna-auth0] Token refresh success for user:', stored.userId);
+    return res.json({
+      access_token: at,
+      refresh_token: newRt,
+      id_token: generateToken('id'),
+      expires_in: 3600,
+      token_type: 'Bearer',
+    });
+  }
+
+  console.log('[mock-cigna-auth0] Unsupported grant_type:', grant_type);
+  return res.status(400).json({ error: 'unsupported_grant_type' });
+}

--- a/pages/api/cigna-auth0/rtde/v1/biometrics.ts
+++ b/pages/api/cigna-auth0/rtde/v1/biometrics.ts
@@ -1,0 +1,14 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { requireBearer } from '../../../../../lib/cigna-auth0/middleware';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const bearer = requireBearer(req, res);
+  if (!bearer) return;
+
+  console.log('[mock-cigna-auth0] GET /rtde/v1/biometrics', { userId: bearer.userId });
+  return res.json({ result: [] });
+}

--- a/pages/api/cigna-auth0/rtde/v1/surveyresponses/[id]/complete.ts
+++ b/pages/api/cigna-auth0/rtde/v1/surveyresponses/[id]/complete.ts
@@ -1,0 +1,19 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { requireBearer } from '../../../../../../../lib/cigna-auth0/middleware';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const bearer = requireBearer(req, res);
+  if (!bearer) return;
+
+  console.log('[mock-cigna-auth0] GET /rtde/v1/surveyresponses/:id/complete', {
+    userId: bearer.userId,
+    surveyResponseId: req.query.id,
+  });
+  return res.json({
+    result: { id: req.query.id, status: 'complete' },
+  });
+}

--- a/pages/api/cigna-auth0/rtde/v1/surveyresponses/index.ts
+++ b/pages/api/cigna-auth0/rtde/v1/surveyresponses/index.ts
@@ -1,0 +1,29 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import crypto from 'crypto';
+import { requireBearer } from '../../../../../../lib/cigna-auth0/middleware';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const bearer = requireBearer(req, res);
+  if (!bearer) return;
+
+  const id = crypto.randomBytes(12).toString('hex');
+  const responseData = {
+    result: {
+      id,
+      surveyId: req.body.surveyId,
+      status: 'incomplete',
+      answers: req.body.answers,
+    },
+  };
+
+  console.log('[mock-cigna-auth0] POST /rtde/v1/surveyresponses', {
+    userId: bearer.userId,
+    request: { surveyId: req.body.surveyId, answers: req.body.answers },
+    response: responseData,
+  });
+  return res.json(responseData);
+}

--- a/pages/api/cigna-auth0/rtde/v1/userinfo.ts
+++ b/pages/api/cigna-auth0/rtde/v1/userinfo.ts
@@ -1,0 +1,32 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { requireBearer } from '../../../../../lib/cigna-auth0/middleware';
+import { TEST_USERS } from '../../../../../lib/cigna-auth0/test-users';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const bearer = requireBearer(req, res);
+  if (!bearer) return;
+
+  const user = TEST_USERS[bearer.userId];
+  const responseData = {
+    sub: user.sub,
+    name: bearer.userId,
+    given_name: user.given_name,
+    family_name: user.family_name,
+    email: user.email,
+    birthdate: user.birthdate,
+    gender: user.gender,
+    updated_at: new Date().toISOString(),
+    eligibility: { products: user.products },
+    plan_sponsor: { id: user.employer_id, name: user.employer_name },
+  };
+
+  console.log('[mock-cigna-auth0] GET /rtde/v1/userinfo', {
+    userId: bearer.userId,
+    response: responseData,
+  });
+  return res.json(responseData);
+}

--- a/pages/api/cigna-auth0/rtde/v3/incentives.ts
+++ b/pages/api/cigna-auth0/rtde/v3/incentives.ts
@@ -1,0 +1,29 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { requireBearer } from '../../../../../lib/cigna-auth0/middleware';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const bearer = requireBearer(req, res);
+  if (!bearer) return;
+
+  console.log('[mock-cigna-auth0] GET /rtde/v3/incentives', { userId: bearer.userId });
+  return res.json({
+    _id: 'mock-incentives',
+    planYears: {
+      '2026': {
+        rewardables: [
+          {
+            goals: [
+              { id: '20019', rewardValue: 25 },
+              { id: '20020', rewardValue: 25 },
+              { id: '20022', rewardValue: 25 },
+            ],
+          },
+        ],
+      },
+    },
+  });
+}

--- a/pages/api/cigna-auth0/well-known/openid-configuration.ts
+++ b/pages/api/cigna-auth0/well-known/openid-configuration.ts
@@ -1,0 +1,22 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const protocol = req.headers['x-forwarded-proto'] || 'http';
+  const host = req.headers.host || 'localhost:4000';
+  const baseUrl = `${protocol}://${host}`;
+
+  return res.json({
+    issuer: `${baseUrl}/`,
+    authorization_endpoint: `${baseUrl}/authorize`,
+    token_endpoint: `${baseUrl}/oauth/token`,
+    userinfo_endpoint: `${baseUrl}/userinfo`,
+    jwks_uri: `${baseUrl}/.well-known/jwks.json`,
+    scopes_supported: ['openid', 'offline_access', 'profile', 'email'],
+    response_types_supported: ['code'],
+    token_endpoint_auth_methods_supported: ['client_secret_basic', 'client_secret_post'],
+  });
+}

--- a/pages/cigna-auth0/authorize.tsx
+++ b/pages/cigna-auth0/authorize.tsx
@@ -1,0 +1,127 @@
+import Head from 'next/head';
+import { useRouter } from 'next/router';
+import { useState } from 'react';
+import { TEST_USERS, CignaTestUser } from '../../lib/cigna-auth0/test-users';
+
+export default function CignaAuthorize() {
+  const router = useRouter();
+  const { redirect_uri, state, client_id } = router.query;
+
+  const [selectedUser, setSelectedUser] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async () => {
+    if (!selectedUser) {
+      setError('Please select a test user');
+      return;
+    }
+
+    const user = TEST_USERS[selectedUser];
+    if (!user) return;
+
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      const response = await fetch('/api/cigna-auth0/authorize/callback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          username: selectedUser,
+          password: user.password,
+          redirect_uri: redirect_uri as string,
+          state: state as string,
+        }),
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        setError(data.error || 'Authentication failed');
+        setIsSubmitting(false);
+        return;
+      }
+
+      window.location.href = data.redirectUrl;
+    } catch (err) {
+      setError('Network error');
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <>
+      <Head>
+        <title>Mock Cigna Auth0 Login</title>
+      </Head>
+      <div className='mx-auto max-w-2xl p-6'>
+        <h1 className='mb-2 text-center text-3xl font-bold'>Mock Cigna Auth0 Login</h1>
+        <p className='mb-6 text-center text-sm text-gray-500'>
+          client_id: {client_id || 'none'} | redirect_uri: {redirect_uri || 'none'}
+        </p>
+
+        {error && (
+          <div className='alert alert-error mb-4'>
+            <span>{error}</span>
+          </div>
+        )}
+
+        <div className='space-y-3'>
+          {Object.entries(TEST_USERS).map(([username, user]: [string, CignaTestUser]) => (
+            <div
+              key={username}
+              className={`card cursor-pointer border-2 bg-base-100 shadow-sm transition-all hover:shadow-md ${
+                selectedUser === username ? 'border-primary bg-primary/5' : 'border-base-300'
+              }`}
+              onClick={() => {
+                setSelectedUser(username);
+                setError(null);
+              }}>
+              <div className='card-body p-4'>
+                <div className='flex items-center justify-between'>
+                  <div>
+                    <h2 className='card-title text-lg'>
+                      {user.given_name} {user.family_name}
+                    </h2>
+                    <p className='text-sm text-gray-500'>
+                      Username: <span className='font-mono'>{username}</span>
+                    </p>
+                  </div>
+                  <div className='text-right text-sm'>
+                    <p>
+                      <span className='font-semibold'>Employer:</span> {user.employer_name}
+                    </p>
+                    <p>
+                      <span className='font-semibold'>Products:</span>{' '}
+                      {user.products.length > 0
+                        ? user.products.map((p) => p.split('/').pop()).join(', ')
+                        : 'None'}
+                    </p>
+                  </div>
+                </div>
+                <div className='mt-1 text-xs text-gray-400'>
+                  {user.email} | DOB: {user.birthdate.split('T')[0]} | Sub: {user.sub}
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <button
+          className={`btn btn-primary btn-block mt-6 ${isSubmitting ? 'loading' : ''}`}
+          onClick={handleSubmit}
+          disabled={!selectedUser || isSubmitting}>
+          {isSubmitting ? 'Signing in...' : 'Sign In'}
+        </button>
+
+        <div className='mt-6 rounded-lg bg-base-200 p-4'>
+          <h3 className='mb-2 font-semibold'>Request Details</h3>
+          <pre className='overflow-auto text-xs'>
+            {JSON.stringify({ redirect_uri, state, client_id, selectedUser }, null, 2)}
+          </pre>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,101 +1,40 @@
-import { GetServerSideProps } from 'next';
 import Link from 'next/link';
 import React from 'react';
-import config from '../lib/env';
-import { IdPMetadata } from '../types';
-import { getEntityId, getSSOUrl } from 'lib/entity-id';
 
-const Home: React.FC<{ metadata: IdPMetadata; params: any }> = ({ metadata, params }) => {
-  const namespace = params.namespace;
-
-  const { ssoUrl: appUrl, entityId, certificate } = metadata;
-  const namespaceEntityId = getEntityId(entityId, namespace);
-  const metadataDownloadUrl =
-    '/api' + (namespace ? `/namespace/${namespace}` : '') + '/saml/metadata?download=true';
-  const metadataUrl = '/api' + (namespace ? `/namespace/${namespace}` : '') + '/saml/metadata';
-  const loginUrl = (namespace ? `/namespace/${namespace}` : '') + '/saml/login';
-  const ssoUrl = getSSOUrl(appUrl, namespace);
+const Home: React.FC = () => {
   return (
     <div className='flex items-center justify-center'>
       <div className='flex w-full max-w-4xl flex-col space-y-5 px-2'>
         <h1 className='text-center text-xl font-extrabold text-gray-900 md:text-2xl'>
-          A free SAML 2.0 Identity Provider for testing SAML SSO integrations.
+          Mock Identity Providers
         </h1>
-        <div className='flex flex-col justify-between space-y-5 md:flex-row md:space-y-0'>
-          <div className='flex flex-col space-y-5 md:flex-row md:space-x-5 md:space-y-0'>
-            <Link href={metadataDownloadUrl} className='btn-primary btn-active btn'>
-              <svg
-                className='mr-1 inline-block h-6 w-6'
-                fill='none'
-                viewBox='0 0 24 24'
-                stroke='currentColor'
-                aria-hidden
-                strokeWidth='2'>
-                <path
-                  strokeLinecap='round'
-                  strokeLinejoin='round'
-                  d='M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4'
-                />
-              </svg>
-              Download Metadata
-            </Link>
-            <Link href={metadataUrl} className='btn-outline btn-primary btn' target='_blank'>
-              Metadata URL
-            </Link>
-          </div>
-          <Link href={loginUrl} className='btn-outline btn-primary btn'>
-            Test IdP Login
-          </Link>
-        </div>
-        <div className='border-2 p-3'>
-          <h2 className='mb-5 text-center text-2xl font-bold text-gray-900'>Mock SAML Metadata</h2>
-          <div className='grid grid-cols-2 gap-y-5 gap-x-5'>
-            <div className='form-control'>
-              <label className='label'>
-                <span className='label-text font-bold'>SSO URL</span>
-              </label>
-              <input type='text' defaultValue={ssoUrl} className='input-bordered input' disabled />
-            </div>
-            <div className='form-control'>
-              <label className='label'>
-                <span className='label-text font-bold'>Entity ID</span>
-              </label>
-              <input type='text' defaultValue={namespaceEntityId} className='input-bordered input' disabled />
-            </div>
-            <div className='form-control col-span-2 w-full'>
-              <label className='label'>
-                <span className='label-text font-bold'>Certificate</span>
-              </label>
-              <textarea
-                className='textarea-bordered textarea h-48'
-                defaultValue={certificate}
-                disabled></textarea>
+        <div className='grid grid-cols-1 gap-5 md:grid-cols-2'>
+          <div className='border-2 p-5'>
+            <h2 className='mb-3 text-center text-2xl font-bold text-gray-900'>Mock Sydney SSO</h2>
+            <p className='mb-4 text-center text-sm text-gray-600'>
+              SAML-based SSO for Anthem/Sydney integration testing.
+            </p>
+            <div className='flex justify-center'>
+              <Link href='/saml/sydney' className='btn-outline btn-primary btn'>
+                Test Sydney Login
+              </Link>
             </div>
           </div>
-        </div>
-        <div className='alert alert-error'>
-          <div>
-            <span className='text-white'>Caution: Not for production use.</span>
+          <div className='border-2 p-5'>
+            <h2 className='mb-3 text-center text-2xl font-bold text-gray-900'>Mock Cigna Auth0</h2>
+            <p className='mb-4 text-center text-sm text-gray-600'>
+              OAuth2/OIDC endpoints for Cigna Auth0 SSO integration testing.
+            </p>
+            <div className='flex justify-center'>
+              <Link href='/cigna-auth0/authorize' className='btn-outline btn-primary btn'>
+                Test Cigna Login
+              </Link>
+            </div>
           </div>
         </div>
       </div>
     </div>
   );
-};
-
-export const getServerSideProps: GetServerSideProps = async ({ params }) => {
-  const metadata: IdPMetadata = {
-    ssoUrl: config.appUrl,
-    entityId: config.entityId,
-    certificate: config.publicKey,
-  };
-
-  return {
-    props: {
-      metadata,
-      params: params ? params : {},
-    },
-  };
 };
 
 export default Home;

--- a/pages/namespace/[namespace]/index.tsx
+++ b/pages/namespace/[namespace]/index.tsx
@@ -1,5 +1,3 @@
-import Home, { getServerSideProps as _getServerSideProps } from '../../index';
-
-export const getServerSideProps = _getServerSideProps;
+import Home from '../../index';
 
 export default Home;


### PR DESCRIPTION
## Summary
- Integrates mock Cigna Auth0 OAuth2/OIDC functionality into mock-saml as Next.js API routes, eliminating the need for a separate mock-cigna-auth0 service
- Adds login page with 4 selectable test users (DaisyUI styled), token exchange, userinfo, biometrics, survey responses, and incentives endpoints with request/response logging
- Adds Next.js rewrites so local dev works without nginx (`/oauth/*`, `/rtde/*`, `/.well-known/*` map to internal API routes)
- Cleans up landing page: removes inherited BoxyHQ branding, replaces with side-by-side cards for Sydney SSO and Cigna Auth0

## Test plan
- [ ] `npm run dev` — verify landing page shows both cards
- [ ] Hit `/cigna-auth0/authorize?redirect_uri=http://localhost:3000&state=test&client_id=test` — verify login page renders with 4 test users
- [ ] Select a user, verify redirect with `?code=...&state=...`
- [ ] POST `/oauth/token?grant_type=authorization_code&code=<code>` — verify token response
- [ ] GET `/rtde/v1/userinfo` with Bearer token — verify user data
- [ ] Check server console for `[mock-cigna-auth0]` log output on each request

https://wildflowerhealth.atlassian.net/browse/SYS-17625