### PR TITLE
Fix token store hot reloads and add unique mock emails

### DIFF
--- a/lib/cigna-auth0/store.ts
+++ b/lib/cigna-auth0/store.ts
@@ -16,12 +16,20 @@ export interface RefreshTokenEntry {
   userId: string;
 }
 
-// In-memory stores. These persist across requests in Next.js standalone mode
-// (single long-running Node process). In dev mode (next dev), module hot-reload
-// may clear these — that's acceptable for a mock service.
-export const authCodes = new Map<string, AuthCodeEntry>();
-export const accessTokens = new Map<string, AccessTokenEntry>();
-export const refreshTokens = new Map<string, RefreshTokenEntry>();
+// In-memory stores. Use globalThis to survive Next.js dev-mode hot reloads.
+const g = globalThis as typeof globalThis & {
+  __mockAuthCodes?: Map<string, AuthCodeEntry>;
+  __mockAccessTokens?: Map<string, AccessTokenEntry>;
+  __mockRefreshTokens?: Map<string, RefreshTokenEntry>;
+};
+
+g.__mockAuthCodes ??= new Map<string, AuthCodeEntry>();
+g.__mockAccessTokens ??= new Map<string, AccessTokenEntry>();
+g.__mockRefreshTokens ??= new Map<string, RefreshTokenEntry>();
+
+export const authCodes = g.__mockAuthCodes;
+export const accessTokens = g.__mockAccessTokens;
+export const refreshTokens = g.__mockRefreshTokens;
 
 export function generateToken(prefix: string): string {
   return `mock-${prefix}-${crypto.randomBytes(16).toString('hex')}`;

--- a/pages/api/cigna-auth0/rtde/v1/userinfo.ts
+++ b/pages/api/cigna-auth0/rtde/v1/userinfo.ts
@@ -11,12 +11,22 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
   if (!bearer) return;
 
   const user = TEST_USERS[bearer.userId];
+  const now = new Date();
+  const timestamp = [
+    String(now.getDate()).padStart(2, '0'),
+    String(now.getMonth() + 1).padStart(2, '0'),
+    String(now.getFullYear()).slice(-2),
+    String(now.getHours()).padStart(2, '0'),
+    String(now.getMinutes()).padStart(2, '0'),
+    String(now.getSeconds()).padStart(2, '0'),
+  ].join('');
+  const uniqueEmail = user.email.replace('@', `+${timestamp}@`);
   const responseData = {
     sub: user.sub,
     name: bearer.userId,
     given_name: user.given_name,
     family_name: user.family_name,
-    email: user.email,
+    email: uniqueEmail,
     birthdate: user.birthdate,
     gender: user.gender,
     updated_at: new Date().toISOString(),


### PR DESCRIPTION
## Summary
- Use `globalThis` for in-memory token stores so they persist across Next.js dev-mode hot reloads (prevents 401s on `/rtde/v1/userinfo` and `/rtde/v1/biometrics`)
- Append DDMMYYHHMMSS timestamp suffix to mock user emails so each SSO login produces a unique email for account creation testing

## Test plan
- [ ] Start mock-saml with `next dev`, complete a Cigna SSO flow — verify userinfo and biometrics don't 401
- [ ] Edit a file to trigger hot reload, repeat SSO flow — verify tokens still work
- [ ] Check the email on the create account screen — verify it has a timestamp suffix (e.g. `joeplayer+130426124618@test.cigna.com`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)